### PR TITLE
Fixed page number of literature/figure/table/listing lists in table of contents

### DIFF
--- a/latex/thesis/thesis.tex
+++ b/latex/thesis/thesis.tex
@@ -257,9 +257,10 @@ Sed in tempus elit, sit amet suscipit quam. Ut suscipit dictum molestie. Etiam q
 %%%%%%%%%%%%%%%%%%%
 %% create figure list
 %%%%%%%%%%%%%%%%%%%
-
-\listoffigures
+\newpage
+\phantomsection
 \addcontentsline{toc}{chapter}{Verzeichnisse}			
+\listoffigures
 
 %%%%%%%%%%%%%%%%%%%
 %% create tables list
@@ -269,11 +270,15 @@ Sed in tempus elit, sit amet suscipit quam. Ut suscipit dictum molestie. Etiam q
 %%%%%%%%%%%%%%%%%%%
 %% create listings list
 %%%%%%%%%%%%%%%%%%%
-%\lstlistoflistings
-%\addcontentsline{toc}{chapter}{Listings}				
+%\newpage
+%\phantomsection
+%\addcontentsline{toc}{chapter}{Listings}
+%\lstlistoflistings			
 
-\printbibliography
-\addcontentsline{toc}{chapter}{Literatur}				
+\newpage
+\phantomsection
+\addcontentsline{toc}{chapter}{Literatur}
+\printbibliography		
 
 %%%%%%%%%%%%%%%%%%%
 %% declaration on oath


### PR DESCRIPTION
This small change fixed the numbering in the table of contents when a list is longer than a single page.

When for example the literatur list was longer than a single page the table of contents would show the number of the last page of the literatur list instead of the first page.

To prevent this the `addcontentsline` command has to be placed before the `printbibliography` command.
Then the `newpage` and `phantomsection` command are used to place the link on the correct page otherwise the link would point to the last page of the previous listing or chapter.

I don't know exactly why `phantomsection` is needed but without one of the two commands it does not work correctly

Greetings